### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -1,4 +1,6 @@
 name: Publish Website
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Gerharddc/litterbox/security/code-scanning/1](https://github.com/Gerharddc/litterbox/security/code-scanning/1)

To fix this issue, it's best to add a `permissions` block with the least privileges required for the workflow at either the workflow root (just after `name:` but before `on:`) or within the job (`build-and-deploy`) definition, unless the job requires different permissions from others (not the case here, as there is only one job). In this case, the workflow only reads from the repository and does not require write permissions to contents, issues, or pull requests. Therefore, add `permissions: contents: read` at the workflow root, just below the `name:` line. No new methods, imports, or definitions are needed; only the YAML permissions block needs to be added.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
