### PR TITLE
Added CachyOS template

### DIFF
--- a/litterbox/src/main.rs
+++ b/litterbox/src/main.rs
@@ -65,6 +65,7 @@ fn extract_stdout(output: &Output) -> Result<&str, LitterboxError> {
 enum Template {
     OpenSuseTumbleweed,
     UbuntuLts,
+    CachyOS,
 }
 
 impl Template {
@@ -72,6 +73,7 @@ impl Template {
         match self {
             Template::OpenSuseTumbleweed => include_str!("../templates/tumbleweed.Dockerfile"),
             Template::UbuntuLts => include_str!("../templates/ubuntu-latest.Dockerfile"),
+            Template::CachyOS => include_str!("../templates/cachyos.Dockerfile"),
         }
     }
 
@@ -79,6 +81,7 @@ impl Template {
         match self {
             Template::OpenSuseTumbleweed => "OpenSUSE Tumbleweed",
             Template::UbuntuLts => "Ubuntu LTS",
+            Template::CachyOS => "CachyOS",
         }
     }
 }

--- a/litterbox/templates/cachyos.Dockerfile
+++ b/litterbox/templates/cachyos.Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1.4
+# adjust according to your CPU architecture level
+FROM docker.io/cachyos/cachyos-v3:latest
+
+# Setup base system (install essential packages)
+RUN pacman -Syu --noconfirm && \
+    pacman -S --noconfirm sudo wayland mesa vulkan-tools vulkan-radeon vulkan-intel openssh git iputils curl iproute2
+
+# Install the fish shell for a nicer experience
+RUN pacman -S --noconfirm fish
+
+# Install development toolchain and additional package managers (ADAPT TO YOUR OWN NEEDS)
+RUN pacman -S --noconfirm base-devel paru mise
+
+# We put these args later to avoid excessive rebuilding
+ARG USER
+ARG PASSWORD
+
+# Setup non-root user with a password for added security
+RUN useradd -m $USER && \
+    echo "${USER}:${PASSWORD}" | chpasswd && \
+    echo "${USER} ALL=(ALL) ALL" >> /etc/sudoers
+WORKDIR /home/$USER
+
+# We do not install things directly into $HOME here as they will get nuked
+# once the home directory gets mounted. Instead we use a script that runs
+# at start-up to construct the home directory the first time.
+#
+# A benefit of not installing things directly into home means that they do
+# need to be re-installed when the container gets rebuilt.
+RUN <<'EOF'
+# Create the script using a nested heredoc
+cat <<'EOT' > /prep-home.sh
+#!/usr/bin/env fish
+
+set MARKER "$HOME/.home-built"
+
+# If the marker file already exists, exit early
+if test -f "$MARKER"
+    echo "Home already built; skipping."
+    exec $SHELL -l
+end
+
+echo "Building home for the first time..."
+
+# ------------------------------
+# ADAPT THIS TO YOUR OWN NEEDS
+# ------------------------------
+fish_add_path -U "$HOME/.local/bin"
+
+# Create the marker file to prevent re-running
+touch "$MARKER"
+echo "Done."
+
+# Return to the normal shell
+exec $SHELL -l
+EOT
+
+chmod +x /prep-home.sh
+chown $USER /prep-home.sh
+EOF
+
+# Enter the fish shell by default
+ENV SHELL=fish
+RUN chsh -s /usr/bin/fish $USER
+CMD ["fish", "/prep-home.sh"]


### PR DESCRIPTION
CachyOS option:
<img width="654" height="204" alt="Screenshot_20260114_133200" src="https://github.com/user-attachments/assets/a82e7478-cb3b-427c-ae22-582952a42d7e" />


Actual change compared to the ubuntu template
```diff
❯ diff -u litterbox/templates/ubuntu-latest.Dockerfile litterbox/templates/cachyos.Dockerfile 
--- litterbox/templates/ubuntu-latest.Dockerfile        2026-01-14 14:56:03.593044219 -0800
+++ litterbox/templates/cachyos.Dockerfile      2026-01-14 16:51:39.725635164 -0800
@@ -1,22 +1,23 @@
 # syntax=docker/dockerfile:1.4
-FROM ubuntu:latest
+# adjust according to your CPU architecture level
+FROM docker.io/cachyos/cachyos-v3:latest
 
-# Setup base system (we install weston to easily get all the Wayland deps)
-RUN apt-get update && \
-    apt-get install -y sudo weston mesa-vulkan-drivers openssh-client git iputils-ping vulkan-tools curl iproute2
+# Setup base system (install essential packages)
+RUN pacman -Syu --noconfirm && \
+    pacman -S --noconfirm sudo wayland mesa vulkan-tools vulkan-radeon vulkan-intel openssh git iputils curl iproute2
 
 # Install the fish shell for a nicer experience
-RUN apt-get install -y fish
+RUN pacman -S --noconfirm fish
 
-# Install development tools (ADAPT TO YOUR OWN NEEDS)
-RUN apt-get install -y clang cmake ninja-build g++
+# Install development toolchain and additional package managers (ADAPT TO YOUR OWN NEEDS)
+RUN pacman -S --noconfirm base-devel paru mise
 
 # We put these args later to avoid excessive rebuilding
 ARG USER
 ARG PASSWORD
 
 # Setup non-root user with a password for added security
-RUN usermod -l $USER ubuntu -m -d /home/$USER && \
+RUN useradd -m $USER && \
     echo "${USER}:${PASSWORD}" | chpasswd && \
     echo "${USER} ALL=(ALL) ALL" >> /etc/sudoers
 WORKDIR /home/$USER
@@ -45,8 +46,6 @@
 # ------------------------------
 # ADAPT THIS TO YOUR OWN NEEDS
 # ------------------------------
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-curl -f https://zed.dev/install.sh | sh
 fish_add_path -U "$HOME/.local/bin"
 
 # Create the marker file to prevent re-running
```