### PR TITLE
Set LANG to en_US.UTF-8

### DIFF
--- a/litterbox/templates/cachyos.Dockerfile
+++ b/litterbox/templates/cachyos.Dockerfile
@@ -60,6 +60,8 @@ chmod +x /prep-home.sh
 chown $USER /prep-home.sh
 EOF
 
+# Set LANG to enable UTF-8 support
+ENV LANG=en_US.UTF-8
 # Enter the fish shell by default
 ENV SHELL=fish
 RUN chsh -s /usr/bin/fish $USER

--- a/litterbox/templates/tumbleweed.Dockerfile
+++ b/litterbox/templates/tumbleweed.Dockerfile
@@ -61,6 +61,8 @@ chmod +x /prep-home.sh
 chown $USER /prep-home.sh
 EOF
 
+# Set LANG to enable UTF-8 support
+ENV LANG=en_US.UTF-8
 # Enter the fish shell by default
 ENV SHELL=fish
 RUN chsh -s /usr/bin/fish $USER

--- a/litterbox/templates/ubuntu-latest.Dockerfile
+++ b/litterbox/templates/ubuntu-latest.Dockerfile
@@ -61,6 +61,8 @@ chmod +x /prep-home.sh
 chown $USER /prep-home.sh
 EOF
 
+# Set LANG to enable UTF-8 support
+ENV LANG=en_US.UTF-8
 # Enter the fish shell by default
 ENV SHELL=fish
 RUN chsh -s /usr/bin/fish $USER


### PR DESCRIPTION
This enables UTF-8 support in terminal commands (e.g. jj).