### PR TITLE
Add xwayland support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,7 +7,7 @@
 A minimal, statically-linked binary designed to run inside Litterbox containers. It handles two commands:
 
 - **entrypoint**: Initializes the user's home directory and launches the login shell inside the container. Handles privilege dropping and wait behaviour for background processes.
-- **wait**: Blocks until the session lock file is empty (all terminals closed), then waits for child processes to exit.
+- **wait**: Blocks until the session lock file is empty (all terminals closed), then waits for child processes to exit. Also starts `xwayland-satellite` as a background daemon if it is installed.
 
 **Key characteristics:**
 
@@ -61,8 +61,8 @@ A new short-livived process is spawned for each confirmation dialog. This is mai
 
 **Starting:**
 
-- The container entrypoint is `/lbx-init wait`, which blocks until the session lock file is empty
-- This is detected using inotify for efficient watching
+- The container entrypoint is `/lbx-init wait`, which blocks until the session lock file is empty; this is detected using inotify for efficient watching
+- If `xwayland-satellite` is present in `$PATH`, it is started as a background daemon; `DISPLAY` is passed as a positional argument if set
 
 **Stopping:**
 

--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ Litterbox is still very much WIP with many missing features or required improvem
 - [x] Add optional support for port forwarding with the default "pasta" networking.
 - [x] Support entering a Litterbox multiple times.
 - [x] Use `Landlock` to improve isolation strength.
+- [x] Make it possible for X11 apps to run via `xwayland-satellite` integration.
 - [ ] Add a "prune" command to get rid of dangling images.
 - [ ] Add support for more granular network settings.
 - [ ] Show SSH key name when prompting for approval. (Currently blocked by https://github.com/Eugeny/russh/issues/602)
 - [ ] Expose limited DBus access to allow applications to open URLs. Likely using [dbus-proxy](https://github.com/Pelagicore/dbus-proxy).
-- [ ] Make it possible for Xorg apps to run via Wayback integration.
 - [ ] Add full support for running on Windows via WSL.
 - [ ] Add Dockerfile templates for more distros.
 - [ ] Add support for more hardware platforms to the installer.

--- a/lbx-init/src/commands/wait.rs
+++ b/lbx-init/src/commands/wait.rs
@@ -3,9 +3,12 @@ use clap::Args;
 use log::{debug, info, warn};
 use nix::sys::{
     inotify::{AddWatchFlags, InitFlags, Inotify},
-    wait::{WaitStatus, waitpid},
+    wait::{WaitPidFlag, WaitStatus, waitpid},
 };
+use std::io::ErrorKind;
 use std::path::Path;
+use std::time::Duration;
+use std::{fs, thread};
 
 /// Wait for the Litterbox to finish (for internal use)
 #[derive(Args, Debug)]
@@ -21,7 +24,7 @@ impl Command {
 
         info!("Litterbox has started");
 
-        start_xwayland_satellite();
+        let satellite_pid = start_xwayland_satellite();
 
         debug!("Waiting for sessions to end");
 
@@ -33,7 +36,7 @@ impl Command {
                     }
                 }
 
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => break,
+                Err(e) if e.kind() == ErrorKind::NotFound => break,
 
                 Err(e) => {
                     log::error!("Failed to read session lock file: {e}");
@@ -48,13 +51,33 @@ impl Command {
 
         // `lbx-init entrypoint` sends them over here.
         loop {
-            match waitpid(None, None) {
+            match waitpid(None, Some(WaitPidFlag::WNOHANG)) {
                 Ok(WaitStatus::Exited(pid, status)) => {
                     debug!("Child process {pid} exited: {status}");
                 }
 
                 Ok(WaitStatus::Signaled(pid, signal, _)) => {
                     debug!("Child process {pid} was killed with signal {signal}");
+                }
+
+                Ok(WaitStatus::StillAlive) => {
+                    // No more zombies ready to reap. Check if any non-xwayland children remain.
+                    let has_other_children = fs::read_to_string("/proc/self/task/self/children")
+                        .ok()
+                        .map(|content| {
+                            content
+                                .split_whitespace()
+                                .filter_map(|s| s.parse::<i32>().ok())
+                                .any(|pid| satellite_pid != Some(pid))
+                        })
+                        .unwrap_or(false);
+
+                    if has_other_children {
+                        thread::sleep(Duration::from_secs(1));
+                    } else {
+                        debug!("Only xwayland daemon left, quitting");
+                        break;
+                    }
                 }
 
                 Ok(status) => {
@@ -77,8 +100,7 @@ impl Command {
     }
 }
 
-fn start_xwayland_satellite() {
-    use std::io::ErrorKind;
+fn start_xwayland_satellite() -> Option<i32> {
     use std::process::Command as ProcessCommand;
 
     let mut cmd = ProcessCommand::new("xwayland-satellite");
@@ -87,10 +109,17 @@ fn start_xwayland_satellite() {
     }
 
     match cmd.spawn() {
-        Ok(_) => info!("Started xwayland-satellite"),
+        Ok(child) => {
+            info!("Started xwayland-satellite");
+            Some(child.id() as i32)
+        }
         Err(e) if e.kind() == ErrorKind::NotFound => {
             debug!("xwayland-satellite not found in PATH");
+            None
         }
-        Err(e) => warn!("Failed to start xwayland-satellite: {e}"),
+        Err(e) => {
+            warn!("Failed to start xwayland-satellite: {e}");
+            None
+        }
     }
 }

--- a/lbx-init/src/commands/wait.rs
+++ b/lbx-init/src/commands/wait.rs
@@ -13,11 +13,16 @@ pub struct Command {}
 
 impl Command {
     pub fn run(self) -> Result<()> {
+        crate::sandbox::apply_landlock()?;
+
         let session_lock_path = Path::new("/session.lock");
         let inotify = Inotify::init(InitFlags::empty())?;
         inotify.add_watch(session_lock_path, AddWatchFlags::IN_MODIFY)?;
 
         info!("Litterbox has started");
+
+        start_xwayland_satellite();
+
         debug!("Waiting for sessions to end");
 
         loop {
@@ -69,5 +74,23 @@ impl Command {
         info!("Litterbox has finished");
 
         Ok(())
+    }
+}
+
+fn start_xwayland_satellite() {
+    use std::io::ErrorKind;
+    use std::process::Command as ProcessCommand;
+
+    let mut cmd = ProcessCommand::new("xwayland-satellite");
+    if let Ok(display) = std::env::var("DISPLAY") {
+        cmd.arg(display);
+    }
+
+    match cmd.spawn() {
+        Ok(_) => info!("Started xwayland-satellite"),
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            debug!("xwayland-satellite not found in PATH");
+        }
+        Err(e) => warn!("Failed to start xwayland-satellite: {e}"),
     }
 }

--- a/lbx-init/src/sandbox.rs
+++ b/lbx-init/src/sandbox.rs
@@ -23,7 +23,8 @@ pub fn apply_landlock() -> Result<()> {
         .add_rules(path_beneath_rules(
             ["/lbx-init", "/prep-home.sh"],
             AccessFs::Execute | AccessFs::ReadFile,
-        ))?;
+        ))?
+        .add_rules(path_beneath_rules(["/session.lock"], AccessFs::ReadFile))?;
 
     match ruleset.restrict_self() {
         Ok(status) => debug!("Landlock sandbox applied: {status:?}"),

--- a/litterbox/templates/cachyos.Dockerfile
+++ b/litterbox/templates/cachyos.Dockerfile
@@ -9,6 +9,10 @@ RUN pacman -Syu --noconfirm && \
 # Install the fish shell for a nicer experience (ADAPT TO YOUR OWN NEEDS)
 RUN pacman -S --noconfirm fish
 
+# Setup support for X11 apps through xwayland (ADAPT TO YOUR OWN NEEDS)
+RUN pacman -S --noconfirm xwayland-satellite
+ENV DISPLAY=:0
+
 # Install development toolchain and additional package managers (ADAPT TO YOUR OWN NEEDS)
 RUN pacman -S --noconfirm gcc
 

--- a/litterbox/templates/tumbleweed.Dockerfile
+++ b/litterbox/templates/tumbleweed.Dockerfile
@@ -8,6 +8,10 @@ RUN zypper refresh && \
 # Install the fish shell for a nicer experience (ADAPT TO YOUR OWN NEEDS)
 RUN zypper in -y fish
 
+# Setup support for X11 apps through xwayland (ADAPT TO YOUR OWN NEEDS)
+RUN zypper in -y xwayland-satellite
+ENV DISPLAY=:0
+
 # Install development toolchain (ADAPT TO YOUR OWN NEEDS)
 RUN zypper in -y gcc
 


### PR DESCRIPTION
This PR incorporates `xwayland-satellite` so that X11 apps can be supported inside Litterbox containers.

Fixes https://github.com/Gerharddc/Litterbox/issues/119.